### PR TITLE
fixed issue8,9

### DIFF
--- a/gui/detail.py
+++ b/gui/detail.py
@@ -18,7 +18,7 @@ class Detail(wx.Frame):
 
     def frame_close(self, event):
         self.Destroy()
-        # wx.Exit()
+        wx.Exit()
         search.call_search()
 
 

--- a/gui/graph.py
+++ b/gui/graph.py
@@ -13,8 +13,6 @@ class Graph(wx.Frame):
 
     def frame_close(self, event):
         self.Destroy()
-        # wx.Exit()
-        # mainGui.call_mainGui()
 
 
 class MainPanel(wx.Panel):
@@ -32,6 +30,4 @@ class MainPanel(wx.Panel):
 
 
 def call_graph():
-    app = wx.App(False)
     Graph(None, wx.ID_ANY, title=u'CHMS | グラフ')
-    app.MainLoop()

--- a/gui/mainGui.py
+++ b/gui/mainGui.py
@@ -14,6 +14,7 @@ class Main(wx.Frame):
 
     def frame_close(self, event):
         self.Destroy()
+        event.Skip()
         wx.Exit()
 
 
@@ -60,7 +61,7 @@ class MainPanel(wx.Panel):
 
         """
         self.frame.Destroy()
-        # wx.Exit()
+        wx.Exit()
         registration.call_register()
 
     def click_button2(self, event):

--- a/gui/mainSearchNote.py
+++ b/gui/mainSearchNote.py
@@ -64,7 +64,7 @@ class NotebookPanel(wx.Notebook):
         self.fiscal_year_panel.year_add_listctrl_item(year_accounting_list)
         self.by_title_panel.title_add_listctrl_item(title_accounting_list)
         self.per_transaction_panel.per_add_listctrl_item(search_money_list, transaction_accounting_list)
-        # graph.call_graph()
+        graph.call_graph()
 
     """
     検索結果画面の機能
@@ -191,5 +191,4 @@ class NotebookPanel(wx.Notebook):
             detail_info_list.append(item.GetText())
 
         self.main_panel.close_frame()
-        # wx.Exit()
         detail.call_detail(detail_info_list)

--- a/gui/registration.py
+++ b/gui/registration.py
@@ -24,7 +24,7 @@ class Register(wx.Frame):
             閉じるイベント
         """
         self.Destroy()
-        # wx.Exit()
+        wx.Exit()
         mainGui.call_mainGui()
 
 
@@ -201,7 +201,7 @@ class MainPanel(wx.Panel):
             print(error_msg)
             wx.MessageBox("登録完了しました。", "登録完了", wx.ICON_INFORMATION)
             self.frame.Destroy()
-            # wx.Exit()
+            wx.Exit()
             mainGui.call_mainGui()
         dlg.Destroy()
 

--- a/gui/search.py
+++ b/gui/search.py
@@ -1,5 +1,5 @@
 import wx
-from . import mainGui, detail, common, graph, mainSearchNote
+from . import mainGui, detail, common, mainSearchNote
 from utils import dataListCreate
 from services import accountingService, baseService, cacheService
 
@@ -17,7 +17,7 @@ class Search(wx.Frame):
 
     def frame_close(self, event):
         self.Destroy()
-        # wx.Exit()
+        wx.Exit()
         mainGui.call_mainGui()
 
 
@@ -142,6 +142,7 @@ class MainPanel(wx.Panel):
 
     def close_frame(self):
         self.frame.Destroy()
+        wx.Exit()
 
 
 def call_search():


### PR DESCRIPTION
issue8,9に対応する修正を行った

# issue8のエラー文の原因
- グラフ画面を表示する際、すでに検索画面が開かれているのに、wx.Appを飛び出し、多重発生状態になり、wx._core.PyNoAppError: The wx.App object must be created first!が表示されていた

# issue8のエラー文の修正内容
- graphからwx.appとmainloopを削除する

# issue8の閉じる2回の原因
- graphがwx.appとmainloopを呼び出すため、発生していた
- 各画面表示の遷移の際に、wx.Exit()を呼び出さず遷移することで、遷移前のコードが実行状態から開放されないため、発生
- 遅延に関してはwx.Exit()の影響

# issue8の閉じる2回の修正内容
- mainGUIにwx.Exit()の前にevent.Skip()を挿入し、画面操作から開放する
- 各画面遷移時にwx.Exit()を追加する

# issue9の原因
- graphが閉じるときにwx.Exit()を飛び出していたため、graphを閉じると、コードの実行自体を終了させてしまっていた。

# issue9の修正内容
- graphからはwx.Exit()を呼ばない